### PR TITLE
Mark result of evaluation of the RHS as `local`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleUnPack"
 uuid = "ce78b400-467f-4804-87d8-8f486da07d0a"
 authors = ["David Widmann"]
-version = "1.0.0"
+version = "1.0.1"
 
 [compat]
 julia = "1"

--- a/src/SimpleUnPack.jl
+++ b/src/SimpleUnPack.jl
@@ -93,7 +93,7 @@ function destructuring_expr(fsym::Symbol, names, rhs)
     end
     return Base.remove_linenums!(
         quote
-            $(esc(object)) = $(esc(rhs)) # In case the RHS is an expression
+            local $(esc(object)) = $(esc(rhs)) # In case the RHS is an expression
             $block
             $(esc(object)) # Return evaluation of the RHS
         end,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,12 @@ macro test_macro_throws(err_expr, expr)
     end
 end
 
+# Module for testing behaviour in global scope (issue #3)
+baremodule A
+using SimpleUnPack
+@unpack a = (a=1.5, b=3)
+end
+
 @testset "SimpleUnPack.jl" begin
     @testset "Variable as RHS" begin
         d = (x=42, y=1.0, z="z1")
@@ -160,5 +166,9 @@ end
         @test_macro_throws ArgumentError @unpack_fields (; x=42, y=1.0)
         @test_macro_throws ArgumentError @unpack_fields x, y, (; x=42, y=1.0)
         @test_macro_throws ArgumentError @unpack_fields x, 1 = (; x=42, y=1.0)
+    end
+
+    @testset "global scope (issue #3)" begin
+        @test names(A; all=true) == [:A, :a]
     end
 end


### PR DESCRIPTION
This should avoid the definition of undesired gensym-ed variables in global scope on Julia < 1.7. It seems UnPack uses the same approach.