### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This allows to get updates for GitHub actions automatically - it is basically an equivalent of CompatHelper. I have used this for my own packages, the [Trixi.jl framework](https://github.com/trixi-framework), and the [SciML organization](https://github.com/SciML). After merging this, you could also enable other Dependabot actions in 'Settings -> Code security and analysis -> Dependabot alerts' and '... -> Dependabot security updates'.

See https://github.com/SciML/MuladdMacro.jl/pull/37